### PR TITLE
Remove deferReply to Prevent Replying Error

### DIFF
--- a/src/client/service/commands/NodeCommand.ts
+++ b/src/client/service/commands/NodeCommand.ts
@@ -9,7 +9,6 @@ const NodeCommand: ServiceExecute = {
 	type: "commands",
 	filePath: __filename,
 	async execute(client: UsingClient, database: IDatabase, interaction: CommandContext) {
-		await interaction.deferReply();
 		await interaction.editOrReply({
 			embeds: [
 				{


### PR DESCRIPTION
Remove unnecessary `deferReply` call to resolve `INTERACTION_ALREADY_REPLIED` error. The deferReply was not required in this context, leading to the interaction already being replied error. This PR simplifies the interaction handling by removing it.

womp womp